### PR TITLE
Add and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-This software originates from the archive found at
-[http://tcts.fpms.ac.be/synthesis/mbrola/tts/English/fs.a10m.tar.gz](http://tcts.fpms.ac.be/synthesis/mbrola/tts/English/fs.a10m.tar.gz)
-
-It contains English text to phoneme converter and pronunciation dictionary
+FreeSpeech contains English text to phoneme converter and pronunciation dictionary
 that being used along with
-[MBROLA](http://tcts.fpms.ac.be/synthesis/mbrola.html)
+[MBROLA](https://github.com/numediart/MBROLA/)
 can provide full TTS functionality for English language.
+
+This software originates from the archive found at
+[http://tcts.fpms.ac.be/synthesis/mbrola/tts/English/fs.a10m.tar.gz](http://tcts.fpms.ac.be/synthesis/mbrola/tts/English/fs.a10m.tar.gz)  
+Since approximately 2019, the resource at this address has been unavailable,
+but the archive with original project has been archived by the Wayback Machine
+and can be downloaded at
+[https://web.archive.org/web/20051029153831/chttp://tcts.fpms.ac.be/synthesis/mbrola/tts/English/fs.a10m.tar.gz](https://web.archive.org/web/20051029153831/chttp://tcts.fpms.ac.be/synthesis/mbrola/tts/English/fs.a10m.tar.gz)  
+(This information is for historical reference only
+and the original archive is not required to build the FreeSpeech software.
+This repository contains all the original source code with subsequent patches.)


### PR DESCRIPTION
* The original Freespeech archive was hosted on the MBROLA project website, which has been unavailable since approximately August 2019.
* The MBROLA project was relicensed and published on GitHub in October 2018.
* The Freespeech project was not transferred to GitHub along with MBROLA.
* Search for a new Freespeech home page did not yield any results.
* An attempt to contact the author of Freespeech, Alistair Conkie, did not yield results (his E-mail no longer functions).

Eventually:

* Added a link to Wayback Machine where you can download the original Freespeech archive.
* Updated link to the MBROLA project.
* The order of information in ReadMe has been changed: now the project description comes first, and then the historical reference.
